### PR TITLE
removed lambda requirements for groundtruth

### DIFF
--- a/use-cases/dpo/RLHF-with-Llama3-on-Studio-DPO.ipynb
+++ b/use-cases/dpo/RLHF-with-Llama3-on-Studio-DPO.ipynb
@@ -85,6 +85,7 @@
     "torch==2.2.1\n",
     "aiofiles\n",
     "peft==0.8.2\n",
+    "awscli==1.35.7\n",
     "trl==0.9.4"
    ]
   },
@@ -746,7 +747,6 @@
     "        'UiConfig':{\n",
     "            'UiTemplateS3Uri': UI_TEMPLATE_S3_URI\n",
     "        },\n",
-    "        'PreHumanTaskLambdaArn': 'arn:aws:lambda:us-east-1:432418664414:function:PRE-PassThrough',\n",
     "        'TaskKeywords': [\n",
     "            'QnA',\n",
     "        ],\n",
@@ -755,10 +755,7 @@
     "        'NumberOfHumanWorkersPerDataObject': 1,\n",
     "        'TaskTimeLimitInSeconds': 60*30,\n",
     "        'TaskAvailabilityLifetimeInSeconds': 60*60*24*10,\n",
-    "        'MaxConcurrentTaskCount': 100,\n",
-    "        'AnnotationConsolidationConfig': {\n",
-    "            'AnnotationConsolidationLambdaArn': 'arn:aws:lambda:us-east-1:432418664414:function:ACS-PassThrough'\n",
-    "        } \n",
+    "        'MaxConcurrentTaskCount': 100\n",
     "    })"
    ]
   },


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Sagemaker Ground Truth Custom labeling jobs no longer requires pre and post annotation lambda files. With this change, I am removing the passthrough lambdas that were put in temporarily. The solution is tested and is in production now.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
